### PR TITLE
Disable Mipmapping on copied character icons.

### DIFF
--- a/src/EclipseLevel/EclipseLevelInCharacterSelection.cs
+++ b/src/EclipseLevel/EclipseLevelInCharacterSelection.cs
@@ -93,7 +93,7 @@ namespace EclipseLevelInCharacterSelection
             Graphics.Blit(source, renderTex);
             RenderTexture previous = RenderTexture.active;
             RenderTexture.active = renderTex;
-            Texture2D readableText = new Texture2D(source.width, source.height);
+            Texture2D readableText = new Texture2D(source.width, source.height,TextureFormat.RGBA32,mipChain: false);
             readableText.ReadPixels(new Rect(0, 0, renderTex.width, renderTex.height), 0, 0);
             readableText.Apply();
             RenderTexture.active = previous;


### PR DESCRIPTION
Using the default parameters for Texture2D causes it to blur ui elements when the texture resolution is set in options.
Fixes #2 